### PR TITLE
fix: ember-can null guard in _removeAbilityObserver — [WP-01] Patch & Tag

### DIFF
--- a/addon/helpers/ability.js
+++ b/addon/helpers/ability.js
@@ -37,6 +37,10 @@ export default Helper.extend({
   },
 
   _removeAbilityObserver() {
+    if (this.propertyName === null) {
+      return;
+    }
+
     removeObserver(this, `ability.${this.propertyName}`, this, 'recompute');
     this.ability && this.ability.destroy();
     setProperties(this, { ability: null, propertyName: null });

--- a/tests/integration/helpers/can-test.js
+++ b/tests/integration/helpers/can-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, clearRender } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { Ability } from 'ember-can';
 import { computed } from '@ember/object';
@@ -10,6 +10,27 @@ import { run } from '@ember/runloop';
 
 module('Integration | Helper | can', function (hooks) {
   setupRenderingTest(hooks);
+
+  module('null propertyName guard', function () {
+    test('it does not crash when _removeAbilityObserver runs before any observer is registered', async function (assert) {
+      assert.expect(2);
+
+      this.owner.register(
+        'ability:post',
+        Ability.extend({
+          canWrite: true,
+        })
+      );
+
+      await render(hbs`{{if (can "write post") "true" "false"}}`);
+      assert
+        .dom(this.element)
+        .hasText('true', 'renders without crash on initial compute');
+
+      await clearRender();
+      assert.ok(true, 'destroy completed without crash');
+    });
+  });
 
   module('classic class', function () {
     test('it works with custom property parser', async function (assert) {


### PR DESCRIPTION
## Summary

Fixes concordnow/atlas-bug-tracker#12

Patches `_removeAbilityObserver` in the Concord `ember-can` fork to add a null guard before calling `removeObserver`. When `this.propertyName` is null (initial state before any observer is registered, or after prior cleanup), the method now returns early instead of passing the invalid event name `ability.null:change` to Ember`s `deactivateObserver`, which crashes on `observer.count--`. Adds a regression test verifying no crash during initial compute and destroy lifecycle.

Fixes concordnow/atlas-bug-tracker#16

## Context

**WP-01** → WP-02 (2 total). This is the first of 2 work packages. WP-01 patches the ember-can fork and tags a new release. WP-02 (in `concordnow/concord-app-front`) updates the tarball reference to consume this fix.

## Decisions

- Guard covers the entire `_removeAbilityObserver` method body (removeObserver + ability.destroy + setProperties reset), not just the removeObserver call. When `propertyName` is null, `ability` is also null — guarding on `propertyName` protects all three operations.
- Regression test targets the specific crash scenario (initial compute where `_removeAbilityObserver` runs before any observer is registered), not a generic lifecycle test.
- Branch and tag pushed to remote during Code layer (not deferred to Delivery) because WP-02 consumes the tag via tarball URL — cross-repo dependency requires the tag to be available before WP-02 can execute.
- Reverted `package-lock.json` changes generated by `npm install` on Node 25/npm 11 — not in scope.

## Out of Scope

- **Upgrade ember-can to v8.0.0** — Major version with breaking API changes (126 invocations, 45 templates). Separate initiative if desired.
- **Missing anti-patterns file for concordnow/ember-can** — Small forked addon, no patterns file in `code-review-patterns/`.

## Changes

| File | Action | Purpose |
|---|---|---|
| `addon/helpers/ability.js` | Modified | Added early return when `this.propertyName === null` in `_removeAbilityObserver` |
| `tests/integration/helpers/can-test.js` | Modified | Added regression test for null propertyName crash scenario |

*Generated by Atlas · Run 2026-02-27-fix-ember-count-undefined*